### PR TITLE
9.2.1 + BiometricEnrollmentScreen & NewUnlockScreen

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKAppLockViewController.m
@@ -150,6 +150,11 @@
     }
 }
 
+- (void)biometricUnlockDeclined:(BOOL)isVerificationMode
+{
+    [self biometricUnlockFailed:isVerificationMode];
+}
+
 - (void)dismissStandaloneBiometricSetup
 {
     [SFSecurityLockout setupTimer];

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.h
@@ -37,6 +37,8 @@ SFSDK_DEPRECATED(9.2, 10.0, "Will be removed in 10.0.")
 
 - (void)biometricUnlockFailed:(BOOL)isVerificationMode;
 
+- (void)biometricUnlockDeclined:(BOOL)isVerificationMode;
+
 @end
 
 SFSDK_DEPRECATED(9.2, 10.0, "Will be removed in 10.0.")

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/AppLockView/SFSDKBiometricViewController.m
@@ -261,7 +261,7 @@ static CGFloat      const kSFBioViewBorderWidth                = 0.5f;
 
 - (void)userDenyBiometricEnablement
 {
-    [self.biometricResponseDelgate biometricUnlockFailed:self.verificationMode];
+    [self.biometricResponseDelgate biometricUnlockDeclined:self.verificationMode];
 }
 
 - (void)showBiometricSetup

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockManager.swift
@@ -27,6 +27,7 @@
 
 import Foundation
 import SwiftUI
+import LocalAuthentication
 
 // Callback block used to launch the app when the screen is unlocked.
 public typealias ScreenLockCallbackBlock = () -> Void
@@ -36,8 +37,11 @@ public class ScreenLockManager: NSObject {
     @objc public static let shared = ScreenLockManager()
     
     private let kScreenLockIdentifier = "com.salesforce.security.screenlock"
+    private let kBiometricStateKey = "com.salesforce.security.biometric.state"
     private var callbackBlock: ScreenLockCallbackBlock? = nil
     
+    public var screenLockUiConfiguration = ScreenLockViewConfiguration()
+
     private override init() {}
     
     // MARK: Screen Lock Manager
@@ -206,9 +210,20 @@ public class ScreenLockManager: NSObject {
         // Send flow will begin notification
         SFSDKCoreLogger.d(ScreenLockManager.self, message: "Sending Screen Lock flow will begin notification")
         NotificationCenter.default.post(name: Notification.Name(rawValue: kSFScreenLockFlowWillBegin), object: nil)
-        
+
+        let _ = hasBiometric()   // Calling this here, to ensure the appropriate `BiometricState`
+        let biometricState = SFPreferences.global().integer(forKey: kBiometricStateKey)
+        if biometricState == BiometricUnlockState.declined.rawValue ||
+            biometricState == BiometricUnlockState.unavailable.rawValue {
+            showPasscodeScreen()
+        } else {
+            showScreenLock(uiView: ScreenLockRetryUIView(configuration: screenLockUiConfiguration))
+        }
+    }
+
+    private func showScreenLock(uiView: ScreenLockRetryUIView) {
         // Launch Screen Lock
-        let screenLockViewController = UIHostingController(rootView: ScreenLockUIView())
+        let screenLockViewController = UIHostingController(rootView: uiView)
         screenLockViewController.modalPresentationStyle = .fullScreen
         SFSDKWindowManager.shared().screenLockWindow().presentWindow(animated: false) {
             SFSDKWindowManager.shared().screenLockWindow().viewController?.present(screenLockViewController, animated: false, completion: nil)
@@ -218,5 +233,87 @@ public class ScreenLockManager: NSObject {
     private struct MobilePolicy: Encodable, Decodable {
         let hasPolicy: Bool
     }
-}
 
+    @objc public func userAllowedBiometricUnlock(allowed: Bool) {
+        setBiometricState(state: allowed ? .approved : .declined)
+    }
+
+    private func setBiometricState(state: BiometricUnlockState) {
+        SFPreferences.global().setInteger(Int(state.rawValue), forKey: kBiometricStateKey)
+        SFPreferences.global().synchronize()
+    }
+
+    public func isBiometricEnrolled() -> Bool {
+        return SFPreferences.global().integer(forKey: kBiometricStateKey) == BiometricUnlockState.approved.rawValue
+    }
+
+    @objc public func hasBiometric() -> Bool {
+        let context = LAContext()
+        var error: NSError?
+        let available = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error)
+        if available {
+            // If biometric was unavailable earlier and is available now, then
+            // that means user wants to use biometric for this app, therefore
+            // updating state to approved.
+            let biometricState = SFPreferences.global().integer(forKey: kBiometricStateKey)
+            if biometricState == BiometricUnlockState.unavailable.rawValue {
+                setBiometricState(state: .approved)
+            }
+        } else {
+            setBiometricState(state: .unavailable)
+            let message = "Device cannot use Touch Id or Face Id. Error: \(String(describing: error))"
+            SFSDKCoreLogger.d(ScreenLockManager.self, message: message)
+        }
+        return available
+    }
+
+    private func saveDevicePasscode() {
+        let secAccessControlbject: SecAccessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault,
+                                                                                      kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+                                                                                      .devicePasscode,
+                                                                                      nil)!
+        let dataToStore = "AnyData".data(using: .utf8)!
+
+        let insertQuery: NSDictionary = [
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrAccessControl: secAccessControlbject,
+            kSecAttrService: "PasscodeAuthentication",
+            kSecValueData: dataToStore as Any,
+        ]
+
+        _ = SecItemAdd(insertQuery as CFDictionary, nil)
+    }
+
+    private func showPasscodeScreen() {
+        saveDevicePasscode()
+        showPasscode()
+    }
+
+    func showPasscode() {
+        let query: NSDictionary = [
+            kSecClass:  kSecClassGenericPassword,
+            kSecAttrService  : "PasscodeAuthentication",
+            kSecUseOperationPrompt : "Sign in"
+        ]
+
+        var typeRef : CFTypeRef?
+
+        let status: OSStatus = SecItemCopyMatching(query, &typeRef) //This will prompt the passcode.
+
+        if (status == errSecSuccess) {
+            unlock()
+        } else {
+            let errorText = SecCopyErrorMessageString(status, nil) as String? ?? ""
+            showRetryUnlockScreen(forPasscode: true, errorText: errorText)
+        }
+    }
+
+    private func showRetryUnlockScreen(forPasscode: Bool, errorText: String) {
+        let view = ScreenLockRetryUIView(configuration: screenLockUiConfiguration,
+                                         hasError: true,
+                                         canEvaluatePolicy: true,
+                                         errorText: errorText,
+                                         isPasscodeRetry: true)
+        showScreenLock(uiView: view)
+    }
+}

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockRetryUIView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockRetryUIView.swift
@@ -1,0 +1,174 @@
+//
+//  ScreenLockRetryUIView.swift
+//  SalesforceSDKCore
+//
+//  Created by on 20/12/21.
+//  Copyright (c) 2021-present, _.com, inc. All rights reserved.
+// 
+//  Redistribution and use of this software in source and binary forms, with or without modification,
+//  are permitted provided that the following conditions are met:
+//  * Redistributions of source code must retain the above copyright notice, this list of conditions
+//  and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials provided
+//  with the distribution.
+//  * Neither the name of salesforce.com, inc. nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission of salesforce.com, inc.
+// 
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+//  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+//  FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+//  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+//  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+//  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+//  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+//  WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import SwiftUI
+import LocalAuthentication
+
+public struct ScreenLockViewConfiguration {
+    public enum Background {
+        case color(UIColor)
+        case image(UIImage)
+    }
+
+    let textColor: UIColor
+    let buttonBackgroundColor: UIColor
+    let buttonTitleColor: UIColor
+    let background: Background
+    let appIconImage: UIImage
+
+    public init(textColor: UIColor = .salesforceDefaultText,
+                buttonTitleColor: UIColor = .white,
+                buttonBackgroundColor: UIColor = .salesforceBlue,
+                appIconImage: UIImage = SFSDKResourceUtils.imageNamed("salesforce-logo"),
+                background: Background = Background.color(.salesforceSystemBackground)) {
+        self.textColor = textColor
+        self.buttonTitleColor = buttonTitleColor
+        self.buttonBackgroundColor = buttonBackgroundColor
+        self.appIconImage = appIconImage
+        self.background = background
+    }
+}
+
+struct ScreenLockRetryUIView: View {
+    @Environment(\.presentationMode) var presentationMode
+    let configuration: ScreenLockViewConfiguration
+    @State var hasError = false
+    @State var canEvaluatePolicy = false
+    @State var errorText = ""
+    @State var isPasscodeRetry = false
+    private let canLogout = true
+
+    var body: some View {
+        ZStack {
+            switch configuration.background {
+            case .color(let color):
+                Color(color)
+            case .image(let image):
+                Image(uiImage: image)
+                    .resizable()
+                    .edgesIgnoringSafeArea(.all)
+            }
+            VStack(alignment: .center, content: {
+                HStack {
+                    Spacer()
+                }
+                Spacer()
+
+                Image(uiImage: configuration.appIconImage)
+                    .resizable()
+                    .frame(width: 125, height: 125, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+                    .offset(y: getImageOffset())
+                    .padding()
+
+                if hasError {
+                    VStack {
+                        Text(errorText)
+                            .foregroundColor(Color(configuration.textColor))
+                            .padding()
+
+                        if canEvaluatePolicy {
+                            Button(action: retryUnlock) {
+                                Text(SFSDKResourceUtils.localizedString("retryButtonTitle"))
+                                    .foregroundColor(Color(configuration.buttonTitleColor))
+                            }
+                            .padding()
+                            .background(Color(configuration.buttonBackgroundColor).cornerRadius(5))
+                        }
+                        if canLogout {
+                            Button(action: { logout() },
+                                   label: {
+                                Text(SFSDKResourceUtils.localizedString("logoutButtonTitle"))
+                                    .foregroundColor(Color(configuration.textColor))
+                            }).padding()
+                        }
+                    }
+                    .offset(y: -50)
+                }
+            })
+        }.onAppear(perform: {
+            if !isPasscodeRetry {
+                showBiometric()
+            }
+        })
+    }
+
+    func retryUnlock() {
+        if isPasscodeRetry {
+            ScreenLockManager.shared.showPasscode()
+        } else {
+            showBiometric()
+        }
+    }
+
+    func showBiometric() {
+        let context = LAContext()
+        var error: NSError?
+        
+        hasError = false
+        if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) {
+            canEvaluatePolicy = true
+            let reason = SFSDKResourceUtils.localizedString("biometricReason")
+            
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, error in
+                if success {
+                    DispatchQueue.main.async {
+                        ScreenLockManager.shared.unlock()
+                    }
+                } else {
+                    errorText = error?.localizedDescription ?? SFSDKResourceUtils.localizedString("fallbackErrorMessage")
+                    hasError = true
+                }
+            }
+        } else {
+            errorText = String(format: SFSDKResourceUtils.localizedString("setUpPasscodeMessage"), SalesforceManager.shared.appDisplayName)
+            hasError = true
+            canEvaluatePolicy = false
+        }
+    }
+    
+    private func getImageOffset() -> CGFloat {
+        return hasError ?
+            (canLogout ?
+                (canEvaluatePolicy ? -290 : -350) :
+                (canEvaluatePolicy ? -350 : -410)
+            ) : -470
+    }
+}
+
+private func logout() {
+    ScreenLockManager.shared.logoutScreenLockUsers();
+
+    if(UIAccessibility.isVoiceOverRunning) {
+        UIAccessibility.post(notification: UIAccessibility.Notification.screenChanged, argument: SFSDKResourceUtils.localizedString("accessibilityLoggedOutAnnouncement"))
+    }
+}
+
+struct ScreenLockRetryUIView_Previews: PreviewProvider {
+    static var previews: some View {
+        ScreenLockRetryUIView(configuration: ScreenLockViewConfiguration())
+    }
+}


### PR DESCRIPTION
1. Creates new screen for unlocking app - Security/ScreenLock/ScreenLockRetryUIView.swift
2. Extends functionality to check for SFPreference to decide whether to ask user for passcode or biometric for unlocking. - Security/ScreenLock/ScreenLockManager.swift
3. Shows `SFSDKBiometricViewController` from `UserAccount/SFUserAccountManager.m`
4. Uses different functions in protocol `SFSDKBiometricViewDelegate` to differentiate between when user does not want to go for Biometrics vs when users says Yes but then goes for 'Don't Allow' in the alert from iOS.
5. Calls `finalizeAuthCompletion` after biometric enrollment after login. This fixes the bug of posting login notification even when biometric is not finished.