### PR TITLE
Handles scenario when device passcode is not enabled

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockManager.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockManager.swift
@@ -212,6 +212,10 @@ public class ScreenLockManager: NSObject {
         // Launch Screen Lock
         let screenLockViewController = UIHostingController(rootView: ScreenLockRetryUIView(configuration: screenLockUiConfiguration))
         screenLockViewController.modalPresentationStyle = .fullScreen
+
+        // User can switch back to host app, while lock window is already presented.
+        // So, need to remove previously presented lock window before showing new one.
+        SFSDKWindowManager.shared().screenLockWindow().dismissWindow()
         SFSDKWindowManager.shared().screenLockWindow().presentWindow(animated: false) {
             SFSDKWindowManager.shared().screenLockWindow().viewController?.present(screenLockViewController, animated: false, completion: nil)
         }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockRetryUIView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockRetryUIView.swift
@@ -100,6 +100,13 @@ struct ScreenLockRetryUIView: View {
                             }
                             .padding()
                             .background(Color(configuration.buttonBackgroundColor).cornerRadius(5))
+                        } else {
+                            Button(action: openSetup) {
+                                Text(SFSDKResourceUtils.localizedString("screenLockSetupButtonTitle"))
+                                    .foregroundColor(Color(configuration.buttonTitleColor))
+                            }
+                            .padding()
+                            .background(Color(configuration.buttonBackgroundColor).cornerRadius(5))
                         }
                         if canLogout {
                             Button(action: { logout() },
@@ -147,15 +154,19 @@ struct ScreenLockRetryUIView: View {
         }
     }
     
+    func openSetup() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        }
+    }
+
     private func getImageOffset() -> CGFloat {
         var offset: CGFloat = -470
         if hasError {
             if configuration.shouldShowError && !errorText.isEmpty {
                 offset += 60
             }
-            if canEvaluatePolicy {
-                offset += 60
-            }
+            offset += 60
             if canLogout {
                 offset += 60
             }

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockRetryUIView.swift
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Security/ScreenLock/ScreenLockRetryUIView.swift
@@ -83,26 +83,23 @@ struct ScreenLockRetryUIView: View {
                 Image(uiImage: configuration.appIconImage)
                     .resizable()
                     .frame(width: 125, height: 125, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
-                    .offset(y: getImageOffset())
-                    .padding()
+
+                Spacer()
+                Spacer()
 
                 if hasError {
                     VStack {
-                        if configuration.shouldShowError {
+                        // If canEvaluatePolicy = false, then Retry button is not shown. So, we need to
+                        // definitely show error on screen for user to understand the problem.
+                        if configuration.shouldShowError || !canEvaluatePolicy {
                             Text(errorText)
+                                .multilineTextAlignment(.center)
                                 .foregroundColor(Color(configuration.textColor))
                                 .padding()
                         }
                         if canEvaluatePolicy {
                             Button(action: retryUnlock) {
                                 Text(SFSDKResourceUtils.localizedString("retryButtonTitle"))
-                                    .foregroundColor(Color(configuration.buttonTitleColor))
-                            }
-                            .padding()
-                            .background(Color(configuration.buttonBackgroundColor).cornerRadius(5))
-                        } else {
-                            Button(action: openSetup) {
-                                Text(SFSDKResourceUtils.localizedString("screenLockSetupButtonTitle"))
                                     .foregroundColor(Color(configuration.buttonTitleColor))
                             }
                             .padding()
@@ -152,26 +149,6 @@ struct ScreenLockRetryUIView: View {
             hasError = true
             canEvaluatePolicy = false
         }
-    }
-    
-    func openSetup() {
-        if let url = URL(string: UIApplication.openSettingsURLString) {
-            UIApplication.shared.open(url, options: [:], completionHandler: nil)
-        }
-    }
-
-    private func getImageOffset() -> CGFloat {
-        var offset: CGFloat = -470
-        if hasError {
-            if configuration.shouldShowError && !errorText.isEmpty {
-                offset += 60
-            }
-            offset += 60
-            if canLogout {
-                offset += 60
-            }
-        }
-        return offset
     }
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Views/SFSDKWindowManager.m
@@ -561,12 +561,15 @@ static NSString *const kSFScreenLockWindowKey = @"screenlock";
 }
 @end
 
-@implementation SFSDKUIWindow
+@implementation SFSDKUIWindow {
+    BOOL deallocating;
+}
 
 - (instancetype)initWithFrame:(CGRect)frame {
     self = [super initWithFrame:frame];
     if (self) {
         _windowName = @"NONAME";
+        deallocating = NO;
     }
     return self;
 }
@@ -575,6 +578,7 @@ static NSString *const kSFScreenLockWindowKey = @"screenlock";
     self = [super initWithFrame:frame];
     if (self) {
         _windowName = windowName;
+        deallocating = NO;
     }
     return self;
 }
@@ -619,6 +623,11 @@ static NSString *const kSFScreenLockWindowKey = @"screenlock";
 }
 
 - (void)disableWindow {
+    if (deallocating) {
+        [SFSDKCoreLogger i:[self class] format:@"Skipping disableWindow for %@ window because it's deallocating", _windowName];
+        return;
+    }
+
     BOOL isActive = self.windowScene.activationState == UISceneActivationStateForegroundActive;
     // TODO: Remove isScreenLockWindow check when min iOS is 15.  
     if (([self isSnapshotWindow] || isActive) && ![self isScreenLockWindow]) {
@@ -628,6 +637,10 @@ static NSString *const kSFScreenLockWindowKey = @"screenlock";
         super.rootViewController = nil;
         [self stashRootViewController];
     }
+}
+
+- (void)dealloc {
+    deallocating = YES;
 }
 
 - (BOOL)isSnapshotWindow {

--- a/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCoreTests/SFSDKWindowManagerTests.m
@@ -235,6 +235,19 @@
     [self waitForExpectations:@[delegate.before,delegate.after] timeout:2];
     
     XCTAssertTrue(delegate.notificationWindow.isAuthWindow);
-    
 }
+
+- (void)testDealloc {
+    __weak SFSDKWindowContainer *container;
+    @autoreleasepool {
+        container = [[SFSDKWindowManager sharedManager] createNewNamedWindow:@"customWindow"];
+        [container presentWindow];
+        [[SFSDKWindowManager sharedManager] removeNamedWindow:@"customWindow"];
+    }
+
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"window == nil"];
+    XCTNSPredicateExpectation *expectation = [[XCTNSPredicateExpectation alloc] initWithPredicate:predicate object:container];
+    [self waitForExpectations:@[expectation] timeout:10];
+}
+
 @end

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -59,7 +59,6 @@
 "setUpPasscodeMessage" = "%@ requires you to set up an iOS passcode to use the app.";
 "fallbackErrorMessage" = "An unexpected error occurred.";
 "accessibilityLoggedOutAnnouncement" = "You are logged out.";
-"screenLockSetupButtonTitle" = "Setup Lock Screen";
 
 // OAuth flow
 "authAlertContinueButton"="Continue";

--- a/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
+++ b/shared/resources/SalesforceSDKResources.bundle/en.lproj/Localizable.strings
@@ -59,6 +59,7 @@
 "setUpPasscodeMessage" = "%@ requires you to set up an iOS passcode to use the app.";
 "fallbackErrorMessage" = "An unexpected error occurred.";
 "accessibilityLoggedOutAnnouncement" = "You are logged out.";
+"screenLockSetupButtonTitle" = "Setup Lock Screen";
 
 // OAuth flow
 "authAlertContinueButton"="Continue";


### PR DESCRIPTION
For iOS devices where device passcode is not enabled, then ScreenLockRetry screen would show a button that redirects to app specific device settings.