### PR TITLE
Adds a nil check to avoid crash at removeObject, Line 103 for 'key cannot be nil'

### DIFF
--- a/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFSDKSafeMutableDictionary.m
+++ b/libs/SalesforceSDKCommon/SalesforceSDKCommon/Classes/Util/SFSDKSafeMutableDictionary.m
@@ -100,7 +100,9 @@
 
 - (void)removeObject:(id<NSCopying>)aKey {
     dispatch_barrier_async(self.queue, ^{
-        [self.backingDictionary removeObjectForKey:aKey];
+        if (aKey != nil) {
+            [self.backingDictionary removeObjectForKey:aKey];
+        }
     });
 }
 


### PR DESCRIPTION
Adds a nil check to avoid crash at __43-[SFSDKSafeMutableDictionary removeObject:]_block_invoke + 103 for 'Fatal Exception: NSInvalidArgumentException' 'key cannot be nil'.