### PR TITLE
Loading custom URL from the Host app on the Login Page Web View.

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator+Internal.h
@@ -48,6 +48,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong ,nullable) SFOAuthCredentials *spAppCredentials;
 @property (nonatomic, weak, nullable) SFSDKAuthSession *authSession;
 
+/// This faciliates loading a URL from the Host app.
+@property (nonatomic, strong, nullable) NSURL *loginUrl;
+
 - (instancetype)initWithAuthSession:(SFSDKAuthSession *)authSession;
 
 /** UpdateCredentials and record changes to instanceUrl,accessToken,communityId

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/OAuth/SFOAuthCoordinator.m
@@ -400,7 +400,8 @@
     if ([self.delegate respondsToSelector:@selector(oauthCoordinator:willBeginAuthenticationWithView:)]) {
         [self.delegate oauthCoordinator:self willBeginAuthenticationWithView:self.view];
     }
-    NSString *approvalUrlString = [self generateApprovalUrlString];
+    NSString *approvalUrlString = (self.loginUrl == nil) ? [self generateApprovalUrlString] : self.loginUrl.absoluteString;
+    self.loginUrl = nil;
     [self loadWebViewWithUrlString:approvalUrlString cookie:YES];
 }
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager+Internal.h
@@ -193,7 +193,8 @@ Set this block to handle presentation of the Authentication View Controller.
 
 - (BOOL)loginWithCompletion:(nullable SFUserAccountManagerSuccessCallbackBlock)completionBlock
                     failure:(nullable SFUserAccountManagerFailureCallbackBlock)failureBlock
-                      scene:(nullable UIScene *)scene;
+                      scene:(nullable UIScene *)scene 
+                   loginUrl:(nullable NSURL *)loginUrl;
 
 @end
 

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -348,13 +348,16 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
 - (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
     BOOL result = NO;
     for (UIScene *scene in [SFApplicationHelper sharedApplication].connectedScenes) {
-        result |= [self loginWithCompletion:completionBlock failure:failureBlock scene:scene];
+        result |= [self loginWithCompletion:completionBlock failure:failureBlock scene:scene loginUrl:nil];
     }
     return result;
 }
 
-- (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock scene:(UIScene *)scene {
-    return [self authenticateWithCompletion:completionBlock failure:failureBlock scene:scene];
+- (BOOL)loginWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock 
+                    failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock 
+                      scene:(UIScene *)scene 
+                   loginUrl:(nullable NSURL *)loginUrl {
+    return [self authenticateWithCompletion:completionBlock failure:failureBlock scene:scene loginUrl:loginUrl];
 }
 
 - (BOOL)refreshCredentials:(SFOAuthCredentials *)credentials completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
@@ -426,7 +429,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     }
 }
 
-- (BOOL)authenticateWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock scene:(UIScene *)scene {
+- (BOOL)authenticateWithCompletion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock 
+                           failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock 
+                             scene:(UIScene *)scene 
+                          loginUrl:(nullable NSURL *)loginUrl {
     SFSDKAuthSession *authSession = self.authSessions[scene.session.persistentIdentifier];
     if (authSession && authSession.isAuthenticating) {
         [SFSDKCoreLogger e:[self class] format:@"Login has already been called. Stop current authentication using SFUserAccountManager::stopCurrentAuthentication and then retry."];
@@ -441,7 +447,7 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     if (request.idpEnabled) {
        return [self authenticateUsingIDP:request completion:completionBlock failure:failureBlock];
     }
-    return [self authenticateWithRequest:request completion:completionBlock failure:failureBlock];
+    return [self authenticateWithRequest:request loginUrl:loginUrl completion:completionBlock failure:failureBlock];
 }
 
 -(SFSDKAuthRequest *)defaultAuthRequest {
@@ -462,12 +468,16 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
     return request;
 }
 
-- (BOOL)authenticateWithRequest:(SFSDKAuthRequest *)request completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
+- (BOOL)authenticateWithRequest:(SFSDKAuthRequest *)request 
+                       loginUrl:(nullable NSURL *)loginUrl
+                     completion:(SFUserAccountManagerSuccessCallbackBlock)completionBlock 
+                        failure:(SFUserAccountManagerFailureCallbackBlock)failureBlock {
     SFSDKAuthSession *authSession = [[SFSDKAuthSession alloc] initWith:request credentials:nil];
     authSession.isAuthenticating = YES;
     authSession.authFailureCallback = failureBlock;
     authSession.authSuccessCallback = completionBlock;
     authSession.oauthCoordinator.delegate = self;
+    authSession.oauthCoordinator.loginUrl = loginUrl;
     NSString *sceneId = authSession.sceneId;
     self.authSessions[sceneId] = authSession;
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Util/SFSDKAuthHelper.h
@@ -35,19 +35,25 @@ NS_SWIFT_NAME(AuthHelper)
 /**
  Initiate a login flow if the user is not already logged in to Salesforce and if the app config's `shouldAuthenticate` flag is set to false.
  
+ @param loginUrl When host app can use this param to start login with a specific URL.
  @param completionBlock Block that executes immediately if the user is already logged in, or if the app config's `shouldAuthenticate` is set to false.
                         Otherwise, this block executes after the user logs in successfully, if login is required.
  */
-+ (void)loginIfRequired:(nullable void (^)(void))completionBlock;
++ (void)loginIfRequired:(nullable NSURL *)loginUrl completion:(nullable void (^)(void))completionBlock;
 
 /**
  Initiate a login flow if the user is not already logged in to Salesforce and if the app config's `shouldAuthenticate` flag is set to false.
  
  @param scene Scene that login is initiated for.
+ @param loginUrl When host app can use this param to start login with a specific URL.
+ @param fromLogout To distinguish when this method is called after user logout for showing login screen.
  @param completionBlock Block that executes immediately if the user is already logged in, or if the app config's `shouldAuthenticate` is set to false.
                         Otherwise, this block executes after the user logs in successfully, if login is required.
  */
-+ (void)loginIfRequired:(UIScene *)scene completion:(nullable void (^)(void))completionBlock;
++ (void)loginIfRequired:(UIScene *)scene
+               loginUrl:(nullable NSURL *)loginUrl
+             fromLogout:(BOOL)fromLogout
+             completion:(nullable void (^)(void))completionBlock;
 
 + (void)handleLogout:(nullable void (^)(void))completionBlock;
 


### PR DESCRIPTION
1. Introduces `loginURL` as a property in `SFOAuthCoordinator` and as… in param in `loginIfRequired` method of `SFSDKAuthHelper`.
2. This loginURL is used in 'UserAgentFlow' of `SFOAuthCoordinator` to load in web view.
3. Introduces `fromLogout` flag in `loginIfRequired()` in `SFSDKAuthHelper` to differentiate when login flow is initiated after a logout action.
4. If login starts after logout the logoutBlock is invoked before login and is not registered as a loginBlock.
5. Screen Lock should be shown in `loginIfRequired` method only when it is not logout flow and there is a current user.